### PR TITLE
Prevent article card overflow on flip interaction

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -239,49 +239,85 @@ a {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
   gap: 1.8rem;
+  align-items: stretch;
 }
 
 .article-card {
-  background: var(--card-bg);
-  border-radius: var(--rounded-lg);
-  border: 2px solid transparent;
-  box-shadow: var(--shadow);
-  padding: 1.6rem 1.4rem 1.4rem;
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
+  perspective: 1600px;
   position: relative;
-  overflow: hidden;
-  transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
-}
-
-.article-card::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  border-radius: inherit;
-  padding: 2px;
-  background: linear-gradient(135deg, rgba(93, 169, 233, 0.45), rgba(255, 217, 102, 0.45));
-  opacity: 0;
-  transition: opacity 0.2s ease;
-  z-index: 0;
+  height: 100%;
+  transition: transform 0.25s ease;
 }
 
 .article-card:hover,
 .article-card:focus-within {
   transform: translateY(-6px);
+}
+
+.card-link-wrapper {
+  display: block;
+  position: relative;
+  height: 100%;
+  color: inherit;
+  text-decoration: none;
+  border-radius: var(--rounded-lg);
+}
+
+.card-link-wrapper:focus-visible {
+  outline: 3px solid rgba(93, 169, 233, 0.6);
+  outline-offset: 4px;
+}
+
+.card-inner {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  min-height: 280px;
+  transform-style: preserve-3d;
+  transition: transform 0.6s ease;
+  border-radius: var(--rounded-lg);
+}
+
+.article-card:hover .card-inner,
+.article-card:focus-within .card-inner {
+  transform: rotateY(180deg);
+}
+
+.card-face {
+  position: absolute;
+  inset: 0;
+  padding: 1.6rem 1.4rem 1.4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  background: var(--card-background, var(--card-bg));
+  border-radius: var(--rounded-lg);
+  border: 2px solid transparent;
+  box-shadow: var(--shadow);
+  backface-visibility: hidden;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  overflow: hidden;
+}
+
+.article-card:hover .card-face,
+.article-card:focus-within .card-face {
   border-color: rgba(93, 169, 233, 0.45);
   box-shadow: 0 28px 40px rgba(20, 43, 80, 0.25);
 }
 
-.article-card:hover::before,
-.article-card:focus-within::before {
-  opacity: 1;
+.card-face--back {
+  transform: rotateY(180deg);
+  justify-content: space-between;
+  gap: 0.75rem;
 }
 
-.article-card-content {
-  position: relative;
-  z-index: 1;
+.card-back-body {
+  flex: 1;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding-right: 0.25rem;
 }
 
 .card-meta {
@@ -297,12 +333,15 @@ a {
   margin: 0;
   font-weight: 700;
   min-height: 3em;
+  word-break: break-word;
 }
 
 .card-description {
   margin: 0;
   color: var(--text-muted);
   font-size: 0.95rem;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
 }
 
 .card-tags {
@@ -321,25 +360,24 @@ a {
   font-weight: 600;
 }
 
-.card-link {
+.card-cta {
+  margin-top: auto;
+  font-size: 0.85rem;
+  color: var(--accent-blue);
+  font-weight: 600;
   display: inline-flex;
   align-items: center;
   gap: 0.35rem;
-  text-decoration: none;
-  color: var(--accent-blue);
-  font-weight: 600;
-  margin-top: 0.6rem;
 }
 
-.card-link svg {
-  width: 16px;
-  height: 16px;
-  transition: transform 0.2s ease;
+.card-cta::after {
+  content: '↗';
+  font-size: 0.8rem;
 }
 
-.card-link:hover svg,
-.card-link:focus svg {
-  transform: translateX(3px);
+.card-title--back {
+  font-size: 1.1rem;
+  word-break: break-word;
 }
 
 .site-footer {

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -150,8 +150,17 @@ function createArticleCard(article) {
   const card = document.createElement('article');
   card.className = 'article-card';
 
-  const content = document.createElement('div');
-  content.className = 'article-card-content';
+  const link = document.createElement('a');
+  link.href = article.url;
+  link.target = '_blank';
+  link.rel = 'noopener noreferrer';
+  link.className = 'card-link-wrapper';
+
+  const inner = document.createElement('div');
+  inner.className = 'card-inner';
+
+  const front = document.createElement('div');
+  front.className = 'card-face card-face--front';
 
   const meta = document.createElement('div');
   meta.className = 'card-meta';
@@ -174,10 +183,6 @@ function createArticleCard(article) {
   title.className = 'card-title';
   title.textContent = article.title;
 
-  const description = document.createElement('p');
-  description.className = 'card-description';
-  description.textContent = article.summary || '';
-
   const tags = document.createElement('div');
   tags.className = 'card-tags';
   (article.tags || []).forEach((tagText) => {
@@ -187,15 +192,35 @@ function createArticleCard(article) {
     tags.appendChild(tag);
   });
 
-  const link = document.createElement('a');
-  link.href = article.url;
-  link.target = '_blank';
-  link.rel = 'noopener noreferrer';
-  link.className = 'card-link';
-  link.innerHTML = `読む <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M13.5 4.5H21m0 0v7.5m0-7.5L10.5 15 6 10.5 3 13.5" /></svg>`;
+  front.append(meta, title);
+  if (tags.childElementCount) {
+    front.appendChild(tags);
+  }
 
-  content.append(meta, title, description, tags, link);
-  card.appendChild(content);
+  const back = document.createElement('div');
+  back.className = 'card-face card-face--back';
+
+  const backTitle = document.createElement('h3');
+  backTitle.className = 'card-title card-title--back';
+  backTitle.textContent = article.title;
+
+  const description = document.createElement('p');
+  description.className = 'card-description';
+  description.textContent = article.summary || 'この記事の詳細はZennでご確認ください。';
+
+  const backBody = document.createElement('div');
+  backBody.className = 'card-back-body';
+  backBody.append(backTitle, description);
+
+  const cta = document.createElement('span');
+  cta.className = 'card-cta';
+  cta.textContent = 'クリックで記事を開く';
+
+  back.append(backBody, cta);
+
+  inner.append(front, back);
+  link.appendChild(inner);
+  card.appendChild(link);
   applyCardBackground(card, article.category);
   return card;
 }
@@ -209,7 +234,9 @@ function applyCardBackground(card, category) {
     ライフハック: 'linear-gradient(135deg, rgba(255, 180, 143, 0.2), rgba(93, 169, 233, 0.08))',
   };
 
-  card.style.backgroundImage = gradients[category] ?? 'linear-gradient(135deg, rgba(93, 169, 233, 0.1), rgba(42, 117, 187, 0.06))';
+  const gradient =
+    gradients[category] ?? 'linear-gradient(135deg, rgba(93, 169, 233, 0.1), rgba(42, 117, 187, 0.06))';
+  card.style.setProperty('--card-background', gradient);
 }
 
 function renderError(message) {


### PR DESCRIPTION
## Summary
- wrap the back of each article card in a scrollable body so long summaries stay within the card
- allow card content to wrap and stretch uniformly to avoid spilling text beyond the flip surface
- keep the card grid rows aligned for a cleaner edge along the right side of the viewport

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_b_68e4b4b7cbe883278aba143d0a0783d7