### PR TITLE
Add shimmering silver trading card borders to article cards

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -295,14 +295,70 @@ a {
   border: 2px solid transparent;
   box-shadow: var(--shadow);
   backface-visibility: hidden;
-  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  transition: box-shadow 0.25s ease;
   overflow: hidden;
+  z-index: 0;
+}
+
+.card-face::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  padding: 2px;
+  border-radius: inherit;
+  background: conic-gradient(
+    from 0deg,
+    rgba(255, 255, 255, 0.95) 0deg,
+    #e9edf5 45deg,
+    #c8cedd 120deg,
+    #f7f8fb 180deg,
+    #d0d7e6 240deg,
+    rgba(255, 255, 255, 0.95) 360deg
+  );
+  -webkit-mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+  -webkit-mask-composite: xor;
+  mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+  mask-composite: exclude;
+  animation: border-shimmer 10s linear infinite;
+  pointer-events: none;
+  z-index: -1;
+  filter: drop-shadow(0 0 6px rgba(255, 255, 255, 0.35));
+  transform-origin: center;
+}
+
+.card-face::after {
+  content: "";
+  position: absolute;
+  inset: 2px;
+  border-radius: inherit;
+  background-image:
+    radial-gradient(circle at 18% 26%, rgba(255, 255, 255, 0.8) 0, rgba(255, 255, 255, 0) 55%),
+    radial-gradient(circle at 78% 22%, rgba(202, 220, 255, 0.65) 0, rgba(202, 220, 255, 0) 50%),
+    radial-gradient(circle at 62% 78%, rgba(255, 255, 255, 0.7) 0, rgba(255, 255, 255, 0) 55%),
+    radial-gradient(circle at 28% 72%, rgba(210, 232, 255, 0.6) 0, rgba(210, 232, 255, 0) 50%);
+  background-repeat: no-repeat;
+  opacity: 0.45;
+  mix-blend-mode: screen;
+  pointer-events: none;
+  z-index: -2;
+  transition: opacity 0.3s ease;
+  animation: sparkle-pulse 6s ease-in-out infinite;
 }
 
 .article-card:hover .card-face,
 .article-card:focus-within .card-face {
-  border-color: rgba(93, 169, 233, 0.45);
-  box-shadow: 0 28px 40px rgba(20, 43, 80, 0.25);
+  box-shadow: 0 32px 50px rgba(20, 43, 80, 0.28);
+}
+
+.article-card:hover .card-face::before,
+.article-card:focus-within .card-face::before {
+  animation-duration: 5s;
+  filter: drop-shadow(0 0 10px rgba(240, 248, 255, 0.55));
+}
+
+.article-card:hover .card-face::after,
+.article-card:focus-within .card-face::after {
+  opacity: 0.8;
 }
 
 .card-face--back {
@@ -422,5 +478,26 @@ a {
 
   .search-group {
     max-width: unset;
+  }
+}
+
+@keyframes border-shimmer {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes sparkle-pulse {
+  0%,
+  100% {
+    opacity: 0.35;
+    transform: scale(1);
+  }
+  50% {
+    opacity: 0.85;
+    transform: scale(1.015);
   }
 }


### PR DESCRIPTION
## Summary
- wrap article cards with a conic gradient pseudo-element to create a silver trading card border
- add animated sparkle overlays and shimmer keyframes to reinforce the collectible aesthetic

## Testing
- not run (not required)


------
https://chatgpt.com/codex/tasks/task_b_68e61def516c8327948012ff892d0021