### PR TITLE
Add pagination controls and update feed source

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -242,6 +242,51 @@ a {
   align-items: stretch;
 }
 
+.pagination {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  margin: 2.5rem auto 0;
+}
+
+.pagination.is-hidden {
+  display: none;
+}
+
+.pagination__button {
+  border: 1px solid rgba(29, 29, 31, 0.16);
+  background: #fff;
+  color: var(--text-main);
+  padding: 0.5rem 0.9rem;
+  border-radius: 999px;
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  min-width: 2.5rem;
+}
+
+.pagination__button:hover,
+.pagination__button:focus {
+  border-color: var(--accent-blue);
+  color: var(--accent-blue);
+}
+
+.pagination__button.is-active {
+  background: var(--accent-blue);
+  border-color: var(--accent-blue);
+  color: #fff;
+  box-shadow: 0 8px 16px rgba(42, 117, 187, 0.2);
+  cursor: default;
+}
+
+.pagination__button[disabled],
+.pagination__button[aria-disabled='true'] {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
 .article-card {
   perspective: 1600px;
   position: relative;

--- a/index.html
+++ b/index.html
@@ -72,6 +72,7 @@
       <section id="articles" class="article-section" aria-live="polite">
         <div class="container">
           <div class="article-grid" id="articleGrid"></div>
+          <nav id="pagination" class="pagination is-hidden" aria-label="記事一覧のページ切り替え"></nav>
         </div>
       </section>
     </main>

--- a/scripts/fetch_zenn_feed.py
+++ b/scripts/fetch_zenn_feed.py
@@ -14,7 +14,7 @@ from pathlib import Path
 import re
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
-FEED_URL = "https://zenn.dev/urakawa_jinsei/feed"
+FEED_URL = "http://zenn.dev/urakawa_jinsei/feed?all=1"
 PROXY_URL = f"https://r.jina.ai/{FEED_URL}"
 OUTPUT_PATH = REPO_ROOT / "assets" / "data" / "zenn-feed.json"
 ATOM_NS = "{http://www.w3.org/2005/Atom}"


### PR DESCRIPTION
## Summary
- update the Zenn feed URL to use the all-articles endpoint
- add pagination state management and controls to the article listing
- style the new pagination component to match the existing design

## Testing
- python -m compileall scripts

------
https://chatgpt.com/codex/tasks/task_b_68e65d3323348327884e639f26ee5285